### PR TITLE
Adding Site24x7.json, adding health api endpoint

### DIFF
--- a/pages/api/category.js
+++ b/pages/api/category.js
@@ -4,10 +4,8 @@ import _ from 'lodash';
 export default async function handler(req, res) {
   let logs = [];
   if (req.method === 'GET') {
-    let { categories, log } = await getAllCategoryNodes(false, false);
-    if (categories.status !== 200) {
-      res.status(categories.status).json(categories);
-    }
+    let categoryResponse = await getAllCategoryNodes(false, false);
+    let { categories, log } = categoryResponse;
     logs = log;
     if (categories && categories.length > 0) {
       categories.forEach((element) => {

--- a/pages/api/health.js
+++ b/pages/api/health.js
@@ -1,0 +1,46 @@
+export default async function handler(_, res) {
+  const unavailable = { message: 'Service unavailable' };
+
+  let homepage = await fetch(process.env.NEXTAUTH_URL);
+  if (homepage.status !== 200) {
+    res.status(502).json(unavailable);
+    return;
+  }
+
+  let sites = await fetch(`${process.env.NEXTAUTH_URL}/api/findSites`);
+  if (sites.status !== 200) {
+    res.status(502).json(unavailable);
+    return;
+  }
+
+  let sitesResponse = await sites.json();
+  if (!sitesResponse.response || !sitesResponse.response.data || !sitesResponse.response.data.pageContent) {
+    res.status(502).json(unavailable);
+    return;
+  }
+
+  let firstSite = sitesResponse.response.data.pageContent[0].id;
+
+  let catalog = await fetch(`${process.env.NEXTAUTH_URL}/api/catalog?id=${firstSite}`);
+  if (catalog.status !== 200) {
+    res.status(502).json(unavailable);
+    return;
+  }
+
+  let catalogResponse = await catalog.json();
+
+  if (!catalogResponse.catalogItems || !catalogResponse.catalogItems.data || !catalogResponse.catalogItems.data.pageContent) {
+    res.status(502).json(unavailable);
+    return;
+  }
+
+  let firstCatalogItem = catalogResponse.catalogItems.data.pageContent[0];
+
+  let catalogItem = await fetch(`${process.env.NEXTAUTH_URL}/api/catalog/${firstSite}/${firstCatalogItem.item.itemId.itemCode}`);
+  if (catalogItem.status !== 200) {
+    res.status(502).json(unavailable);
+    return;
+  }
+
+  res.status(200).json({ message: 'Welcome to NCR Retail Demo.' });
+}

--- a/site24x7.json
+++ b/site24x7.json
@@ -1,0 +1,22 @@
+{
+  "monitors": [
+    {
+      "frequency_minutes": "5",
+      "headers": {
+        "Cache-Control": "no-cache,no-cache,no-cache,no-cache,no-cache",
+        "Content-Type": "application/json"
+      },
+      "location_profile": "North America",
+      "method": "get",
+      "monitor_groups": [],
+      "name": "BSP Dev Advocate Retail Sample App",
+      "notification_profile": "AV Notification",
+      "threshold_profile": "Web Monitors",
+      "timeout_seconds": 15,
+      "type": "url",
+      "url": "https://retaildemo.ncrcloud.com/api/health",
+      "user_alert_groups": [""],
+      "webhooks": ["SRE site 24/7 Alerts integrations", "PagerDutyIntegration-BSPSRE", "DevEx"]
+    }
+  ]
+}


### PR DESCRIPTION
## Description

This adds the `/api/health` API endpoint for Site24x7 to test against.
**Note** Site 24x7 is not hooked up yet, these are just the files necessary to get started.

## Testing

1. Run locally with the retail demo keys
2. Send a GET request to `/api/health` and confirm 200

## Ticket

MARKET-4729
