### PR TITLE
MARKET-5229: Admin Mobile Navbar Fix

### DIFF
--- a/components/admin/Header.js
+++ b/components/admin/Header.js
@@ -1,19 +1,20 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import Router from 'next/router';
 import React from 'react';
-import NavigationTabs from '~/components/admin/NavigationTabs';
+import Link from 'next/link';
+import { faTachometerAlt, faExternalLinkAlt, faList, faStore, faLayerGroup, faObjectGroup, faShoppingCart } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faHome, faWrench } from '@fortawesome/free-solid-svg-icons';
-import { Collapse, Container, Nav, Navbar, NavItem, NavbarToggler, NavLink, Row, Col, Button, Popover, PopoverBody, PopoverHeader, Spinner, NavbarBrand, NavbarText } from 'reactstrap';
+import { Collapse, Nav, Navbar, NavItem, NavbarToggler, NavLink, Button, Popover, PopoverBody, PopoverHeader, Spinner, NavbarBrand } from 'reactstrap';
 
-const Header = () => {
+
+const Header = ({ activeTab, tabs = true }) => {
   const [exporting, setIsExporting] = useState(false);
 
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
 
   const toggleNav = () => setIsOpen(!isOpen);
-
   const toggle = () => setPopoverOpen(!popoverOpen);
 
   const buildSampleDatabase = () => {
@@ -28,35 +29,101 @@ const Header = () => {
 
   return (
     <>
-      <Navbar dark sticky="true" className="flex-md-no-wrap p-0 sticky-top shadow header-top" expand="md">
+      <Navbar dark sticky="true" className="flex-md-no-wrap pb-3 pb-md-auto sticky-top shadow header-top" expand="md">
         <NavbarBrand href="/admin/dashboard" className="col-md-3 col-lg-2 mr-0 px-3 logo-text">
           MART
         </NavbarBrand>
-        <NavbarToggler onClick={toggleNav} />
-        <Collapse isOpen={isOpen} navbar className="d-flex flex-row-reverse">
-          <Nav className="px-3">
-            <NavItem>
-              <>
-                <Button id="Popover1" type="button" color="primary" className="float-right" onClick={() => buildSampleDatabase()}>
-                  {exporting ? <Spinner color="light" size="sm" /> : <FontAwesomeIcon icon={faWrench} size="1x" />} Build Sample Database
-                </Button>
-                <Popover placement="left" isOpen={popoverOpen} target="Popover1" toggle={toggle}>
-                  <PopoverHeader>Setup Required.</PopoverHeader>
-                  <PopoverBody>
-                    Application keys are required to build out the datbase. Check out the{' '}
-                    <a href="https://github.com/NCR-Corporation/ncr-retail-demo" target="_blank" rel="noreferrer">
-                      Github README
-                    </a>{' '}
-                    for more information.
-                  </PopoverBody>
-                </Popover>
-              </>
-            </NavItem>
-            <NavItem>
-              <NavLink href="/">
-                <FontAwesomeIcon icon={faHome} size="1x" /> Home
-              </NavLink>
-            </NavItem>
+        <NavbarToggler onClick={toggleNav} className="navToggle" />
+        <Collapse isOpen={isOpen} navbar className="flex-row-reverse navbar-collapse pl-1">
+          <Nav className="px-md-3">
+            <div className="flex-column d-block d-sm-none">
+              <NavItem>
+                <Link href="/admin/dashboard">
+                  <a className={`nav-link ${activeTab === 'dashboard' && 'active'} ${!tabs && 'pl-0'}`}>
+                    <FontAwesomeIcon icon={faTachometerAlt} size="sm" className="feather mr-2 pl-1" />
+                    Dashboard
+                  </a>
+                </Link>
+              </NavItem>
+              <NavItem>
+                <Link href="/admin/orders">
+                  <a className={`nav-link ${activeTab === 'orders' ? 'active' : ''}`}>
+                    <FontAwesomeIcon icon={faList} className="feather mr-2 pl-1" size="sm" />
+                    Orders
+                  </a>
+                </Link>
+              </NavItem>
+              <NavItem>
+                <Link href="/admin/sites">
+                  <a className={`nav-link ${activeTab === 'sites' && 'active'}`}>
+                    <FontAwesomeIcon icon={faStore} className="feather mr-2 pl-1" size="sm" />
+                    Sites
+                  </a>
+                </Link>
+              </NavItem>
+              <NavItem>
+                <Link href="/admin/categories">
+                  <a className={`nav-link ${activeTab === 'categories' && 'active'}`}>
+                    <FontAwesomeIcon icon={faLayerGroup} className="feather mr-2 pl-1" size="sm" />
+                    Categories
+                  </a>
+                </Link>
+              </NavItem>
+              <NavItem>
+                <Link href="/admin/groups">
+                  <a className={`nav-link ${activeTab === 'groups' && 'active'}`}>
+                    <FontAwesomeIcon icon={faObjectGroup} className="feather mr-2 pl-1" size="sm" />
+                    Groups
+                  </a>
+                </Link>
+              </NavItem>
+              <NavItem>
+                <Link href="/admin/catalog">
+                  <a className={`nav-link ${activeTab === 'catalog' && 'active'}`}>
+                    <FontAwesomeIcon icon={faShoppingCart} className="feather mr-2 pl-1" size="sm" />
+                    Global Catalog
+                  </a>
+                </Link>
+              </NavItem>
+              <h6 className="sidebar-heading d-flex justify-content-between align-items-center px-3 mt-4 mb-1 text-white">Resources</h6>
+
+              <NavItem>
+                <NavLink href="https://developer.ncr.com/" target="_blank">
+                  <FontAwesomeIcon icon={faExternalLinkAlt} className="feather mr-2" size="sm" />
+                  NCR Documentation & API Specs
+                </NavLink>
+              </NavItem>
+              <NavItem>
+                <NavLink href="https://github.com/NCR-Corporation/ncr-retail-demo" target="_blank">
+                  <FontAwesomeIcon icon={faExternalLinkAlt} className="feather mr-2" size="sm" />
+                  Github Respository
+                </NavLink>
+              </NavItem>
+            </div>
+            <div className="px-2 build-database">
+              <NavItem>
+                <NavLink href="/" className="pl-1">
+                  <FontAwesomeIcon icon={faHome} size="1x" /> Home
+                </NavLink>
+              </NavItem>
+              <NavItem>
+                <>
+                  <Button id="Popover1" type="button" color="primary" className="float-right" onClick={() => buildSampleDatabase()}>
+                    {exporting ? <Spinner color="light" size="sm" /> : <FontAwesomeIcon icon={faWrench} size="1x" />} Build Sample Database
+                  </Button>
+                  <Popover placement="left" isOpen={popoverOpen} target="Popover1" toggle={toggle}>
+                    <PopoverHeader>Setup Required.</PopoverHeader>
+                    <PopoverBody>
+                      Application keys are required to build out the datbase. Check out the{' '}
+                      <a href="https://github.com/NCR-Corporation/ncr-retail-demo" target="_blank" rel="noreferrer">
+                        Github README
+                      </a>{' '}
+                      for more information.
+                    </PopoverBody>
+                  </Popover>
+                </>
+              </NavItem>
+            </div>
           </Nav>
         </Collapse>
       </Navbar>

--- a/components/admin/Layout.js
+++ b/components/admin/Layout.js
@@ -1,16 +1,16 @@
 import React from 'react';
 import Header from '~/components/admin/Header';
-import NavigationTabs from '~/components/admin//NavigationTabs';
+import NavigationTabs from '~/components/admin/NavigationTabs';
 import { Col, Container, Row } from 'reactstrap';
 
 const Layout = (props) => {
   return (
     <div>
-      <Header navigation={false} />
+      <Header navigation={false} activeTab={props.activeTab}/>
       <Container fluid>
         <Row>
           <Col id="sidebarMenu" className="col-md-3 col-lg-2 d-md-block bg-light sidebar collapse bg-light">
-            <div className="sidebar-sticky pt-3">
+            <div className="sidebar-sticky pt-5">
               <NavigationTabs activeTab={props.activeTab} />
             </div>
           </Col>

--- a/components/admin/NavigationTabs.js
+++ b/components/admin/NavigationTabs.js
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTachometerAlt, faExternalLinkAlt, faList, faStore, faLayerGroup, faObjectGroup, faShoppingCart } from '@fortawesome/free-solid-svg-icons';
 import { Nav, NavItem, NavLink } from 'reactstrap';
+
 const NavigationTabs = ({ activeTab, tabs = true }) => {
   return (
     <>

--- a/styles/style.css
+++ b/styles/style.css
@@ -455,6 +455,16 @@ label {
   overflow-y: auto; /* Scrollable contents if viewport is shorter than content. */
 }
 
+.build-database{
+  display: flex;
+}
+
+@media (max-width: 767.98px) {
+  .build-database{
+    display: inline-block;
+  }
+}
+
 @supports ((position: -webkit-sticky) or (position: sticky)) {
   .sidebar-sticky {
     position: -webkit-sticky;
@@ -472,8 +482,12 @@ label {
   color: #999;
 }
 
-.sidebar .nav-link.active {
+.nav-link.active {
   color: #007bff;
+}
+
+.navToggle {
+  border: transparent;
 }
 
 .sidebar .nav-link:hover .feather,


### PR DESCRIPTION
## Description
This fix adds the routing links that are seen on the sidebar in large screens and moves them into the navbar in a togglable menu.

## Testing
The menu should drop down in the admin configure page via the toggle button and should close via that same button. Currently closing the tab outside of the navbar is not supported. The menu should also show the active tab in blue.

Please outline how to test this fix or feature. Include all steps.

1.  Pull down this branch and go to localhost
2. Click on the gear in the top right corner
3.  Change your browser to a device smaller than a tablet.
4. Confirm if the description in the Testing section is accurate

## Ticket

MARKET-5229
